### PR TITLE
[packages] Add Japanese OpenType fonts

### DIFF
--- a/configs/6dots/packages.both
+++ b/configs/6dots/packages.both
@@ -102,6 +102,7 @@ ttf-bitstream-vera
 ttf-dejavu
 ttf-freefont
 ttf-opensans
+adobe-source-han-sans-jp-fonts
 
 # Desktop
 antergos-wallpapers

--- a/configs/antergos/packages.both
+++ b/configs/antergos/packages.both
@@ -107,6 +107,7 @@ ttf-bitstream-vera
 ttf-dejavu
 ttf-freefont
 ttf-opensans
+adobe-source-han-sans-jp-fonts
 
 
 # Desktop


### PR DESCRIPTION
Add [adobe-source-han-sans-jp-fonts](https://www.archlinux.org/packages/community/any/adobe-source-han-sans-jp-fonts/) for Japanese users.
Antergos has **NOT** been included Japanese OUTLINE font ...until now.

> ![](http://azahuse-ajari.blog.so-net.ne.jp/_images/blog/_c45/azahuse-ajari/VirtualBox_Antergos179_06_09_2017_08_39_57-6925c.jpg)
> Japanese Bitmap font (ugly) on Cnchi
